### PR TITLE
Wrap debug calls with if(log.isDebugEnabled())

### DIFF
--- a/src/main/java/com/wolt/osm/parallelpbf/parser/NodeParser.java
+++ b/src/main/java/com/wolt/osm/parallelpbf/parser/NodeParser.java
@@ -88,7 +88,9 @@ public final class NodeParser extends BaseParser<Osmformat.Node, Consumer<Node>>
         Node node = new Node(message.getId(), latitude, longitude);
         node.setTags(parseTags(message.getKeysList(), message.getValsList()));
         node.setInfo(parseInfo(message));
-        log.debug(node.toString());
+        if (log.isDebugEnabled()) {
+            log.debug(node.toString());
+        }
         getCallback().accept(node);
     }
 
@@ -143,7 +145,9 @@ public final class NodeParser extends BaseParser<Osmformat.Node, Consumer<Node>>
                 Info info = new Info(uid, username, version, timestamp * dateGranularity, changeset, visible);
                 node.setInfo(info);
             }
-            log.debug(node.toString());
+            if (log.isDebugEnabled()) {
+                log.debug(node.toString());
+            }
             getCallback().accept(node);
 
         }

--- a/src/main/java/com/wolt/osm/parallelpbf/parser/RelationParser.java
+++ b/src/main/java/com/wolt/osm/parallelpbf/parser/RelationParser.java
@@ -54,7 +54,9 @@ public final class RelationParser extends BaseParser<Osmformat.Relation, Consume
             relation.getMembers().add(member);
         }
 
-        log.debug(relation.toString());
+        if (log.isDebugEnabled()) {
+            log.debug(relation.toString());
+        }
         getCallback().accept(relation);
     }
 }

--- a/src/main/java/com/wolt/osm/parallelpbf/parser/WayParser.java
+++ b/src/main/java/com/wolt/osm/parallelpbf/parser/WayParser.java
@@ -48,7 +48,9 @@ public final class WayParser extends BaseParser<Osmformat.Way, Consumer<Way>> {
             nodeId += node;
             way.getNodes().add(nodeId);
         }
-        log.debug(way.toString());
+        if (log.isDebugEnabled()) {
+            log.debug(way.toString());
+        }
         getCallback().accept(way);
     }
 }


### PR DESCRIPTION
While profiling our own application, which uses this library (thanks a lot!), `toString()` calls used for debugging showed up as dominant in parallelpbf parser. Wrapping them with `if(log.isDebugEnabled()) {}` really helps.

Benchmarks done on AMD 3300x 4 core / 8 thread CPU @ 4.3 GHz. Page cache was cleared before each iteration.
Czech Republic pbf size - 0.7 GiB.
Europe pbf size - 22.5 GiB.

- Reading from HDD:

Code version | Region | 1 thread read time (s) | 4 ... | 8 ...
-- | -- | -- | -- | --
woltapp | Czech Republic | 75 | 23 | 16
traveltime-dev | Czech Republic | 23 | 10 | 10
woltapp | Europe | 2463 | 722 | 525
traveltime-dev | Europe | 700 | 304 | 305

Looks like 4 threads max out HDD read capabilities.

- Reading from NVMe SSD:

Code version | Region | 1 thread read time (s) | 4 ... | 8 ...
-- | -- | -- | -- | --
woltapp | Czech Republic | 80 | 23 | 16
traveltime-dev | Czech Republic | 22 | 7 | 5
woltapp | Europe | 2475 | 748 | 509
traveltime-dev | Europe | 667 | 208 | 153