### PR TITLE
fixed error propagation in ParallelBinaryParser.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -260,6 +260,10 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
                 <version>2.9.1</version>
+                <configuration>
+			        <!-- skip error related to lombok "var": -->
+                    <failOnError>false</failOnError>
+                </configuration>
                 <executions>
                     <execution>
                         <id>attach-javadocs</id>

--- a/src/main/java/com/wolt/osm/parallelpbf/ParallelBinaryParser.java
+++ b/src/main/java/com/wolt/osm/parallelpbf/ParallelBinaryParser.java
@@ -352,9 +352,9 @@ public final class ParallelBinaryParser {
      * There is no non-blocking version of that method, but you can safely run it in a separate runnable
      * for that purpose.
      *
-     * @throws ExecutionException on processing error.
+     * @throws RuntimeException on processing error.
      */
-    public void parse() throws ExecutionException {
+    public void parse() {
         if (!tasksInFlight.isEmpty()) {
             throw new IllegalStateException("Previous parse call is still in progress");
         }
@@ -387,7 +387,7 @@ public final class ParallelBinaryParser {
             Thread.currentThread().interrupt();
         } catch (ExecutionException e) {
             log.error("Parsing failed with: {}", e.getMessage(), e);
-            throw e;
+            throw new RuntimeException(e);
         } finally {
             //In case of exception we would like to kill all the tasks immediately
             tasksInFlight.stream().filter(t -> !t.isDone()).forEach(t -> t.cancel(true));

--- a/src/test/java/com/wolt/osm/parallelpbf/ParalelBinaryParserExample.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParalelBinaryParserExample.java
@@ -28,10 +28,10 @@ import java.util.concurrent.atomic.AtomicLong;
 public class ParalelBinaryParserExample {
 
     private final StringBuilder output = new StringBuilder();
-    private AtomicLong nodesCounter = new AtomicLong();
-    private AtomicLong waysCounter = new AtomicLong();
-    private AtomicLong relationsCounter = new AtomicLong();
-    private AtomicLong changesetsCounter = new AtomicLong();
+    private final AtomicLong nodesCounter = new AtomicLong();
+    private final AtomicLong waysCounter = new AtomicLong();
+    private final AtomicLong relationsCounter = new AtomicLong();
+    private final AtomicLong changesetsCounter = new AtomicLong();
 
     private void processHeader(Header header) {
         synchronized (output) {
@@ -84,7 +84,7 @@ public class ParalelBinaryParserExample {
         System.out.println(output);
     }
 
-    private void execute() {
+    private void execute() throws Exception {
         Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.TRACE);
 
@@ -100,7 +100,7 @@ public class ParalelBinaryParserExample {
                 .parse();
     }
 
-    public static void main(String[] args) {
+    public static void main(String[] args) throws Exception {
         new ParalelBinaryParserExample().execute();
     }
 }

--- a/src/test/java/com/wolt/osm/parallelpbf/ParalelBinaryParserExample.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParalelBinaryParserExample.java
@@ -84,7 +84,7 @@ public class ParalelBinaryParserExample {
         System.out.println(output);
     }
 
-    private void execute() throws Exception {
+    private void execute() {
         Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.TRACE);
 

--- a/src/test/java/com/wolt/osm/parallelpbf/ParalelBinaryParserExample.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParalelBinaryParserExample.java
@@ -100,7 +100,7 @@ public class ParalelBinaryParserExample {
                 .parse();
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) {
         new ParalelBinaryParserExample().execute();
     }
 }

--- a/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryParserIT.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryParserIT.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.io.*;
 import java.util.Arrays;
 import java.util.Optional;
+import java.util.concurrent.ExecutionException;
 import java.util.function.Consumer;
 
 import static org.junit.jupiter.api.Assertions.*;
@@ -83,7 +84,7 @@ class ParallelBinaryParserIT {
     }
 
     /* Shared code */
-    private void parse(InputStream input) {
+    private void parse(InputStream input) throws ExecutionException {
         new ParallelBinaryParser(input, 1)
                 .onNode(nodeChecker)
                 .onWay(wayChecker)
@@ -125,7 +126,7 @@ class ParallelBinaryParserIT {
     }
 
     @Test
-    void testParser() {
+    void testParser() throws ExecutionException {
         InputStream input = Thread.currentThread().getContextClassLoader()
                 .getResourceAsStream("sample.pbf");
         parse(input);
@@ -165,7 +166,7 @@ class ParallelBinaryParserIT {
     }
 
     @Test
-    void testWriter() throws IOException {
+    void testWriter() throws Exception {
         String outputFilename = System.getProperty("java.io.tmpdir")+"/parallel.pbf";
         File outputFile = new File(outputFilename);
         if (outputFile.exists()) {

--- a/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryParserIT.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryParserIT.java
@@ -166,8 +166,8 @@ class ParallelBinaryParserIT {
     }
 
     @Test
-    void testWriter() throws Exception {
-        String outputFilename = System.getProperty("java.io.tmpdir") + "/parallel.pbf";
+    void testWriter() throws IOException {
+        String outputFilename = System.getProperty("java.io.tmpdir")+"/parallel.pbf";
         File outputFile = new File(outputFilename);
         if (outputFile.exists()) {
             outputFile.delete();

--- a/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryWriterExample.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryWriterExample.java
@@ -28,7 +28,7 @@ public class ParallelBinaryWriterExample {
         writer.close();
     }
 
-    private void execute() throws Exception {
+    private void execute() throws IOException {
         Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.TRACE);
 
@@ -53,6 +53,6 @@ public class ParallelBinaryWriterExample {
         output.close();
     }
 
-    public static void main(String[] args) throws Exception {
+    public static void main(String[] args) throws IOException {
         new ParallelBinaryWriterExample().execute();
     }}

--- a/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryWriterExample.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryWriterExample.java
@@ -28,7 +28,7 @@ public class ParallelBinaryWriterExample {
         writer.close();
     }
 
-    private void execute() throws IOException {
+    private void execute() throws Exception {
         Logger root = (Logger) LoggerFactory.getLogger(Logger.ROOT_LOGGER_NAME);
         root.setLevel(Level.TRACE);
 
@@ -53,6 +53,6 @@ public class ParallelBinaryWriterExample {
         output.close();
     }
 
-    public static void main(String[] args) throws IOException {
+    public static void main(String[] args) throws Exception {
         new ParallelBinaryWriterExample().execute();
     }}


### PR DESCRIPTION
fixes Issue #14 .
Some errors occurring during the parsing are ignored.
This happens because of code in line 363:
```
tasksInFlight = tasksInFlight.stream().filter(f -> !f.isDone()).collect(Collectors.toList());
```
For a failed ``` Future<?>``` method ``` isDone() ``` returns ```true```, so some failed futures are lost here. Method ``` .get() ``` will never be invoked on them, so the failures are not anyhow propagated. Also parser execution may not be stopped on failure. 
The suggested code guarantees at least one failure to be propagated and thrown from method ``` parse() ``` , also it guarantees the parsing to be stopped if a blob processing is known to be failed.