### PR TITLE
Fix reading visibility flag that has no defined value, when value is not provided visibility must be set to true.

### DIFF
--- a/src/main/java/com/wolt/osm/parallelpbf/parser/BaseParser.java
+++ b/src/main/java/com/wolt/osm/parallelpbf/parser/BaseParser.java
@@ -117,12 +117,13 @@ public abstract class BaseParser<M, T extends Consumer<?>> {
     private Info convertInfo(final Osmformat.Info infoMessage) {
         if (infoMessage != null) {
             String username = stringTable.getS(infoMessage.getUserSid()).toStringUtf8();
+            boolean isVisible = !infoMessage.hasVisible() || infoMessage.getVisible();
             return new Info(infoMessage.getUid(),
                     username,
                     infoMessage.getVersion(),
                     infoMessage.getTimestamp(),
                     infoMessage.getChangeset(),
-                    infoMessage.getVisible());
+                    isVisible);
         }
         return null;
     }

--- a/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryParserIT.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/ParallelBinaryParserIT.java
@@ -160,7 +160,7 @@ class ParallelBinaryParserIT {
         assertEquals(1, taggedWay.getInfo().getVersion());
         assertEquals(1334007464L, taggedWay.getInfo().getTimestamp());
         assertEquals(11245909, taggedWay.getInfo().getChangeset());
-        assertFalse(taggedWay.getInfo().isVisible());
+        assertTrue(taggedWay.getInfo().isVisible());
 
         testRelation();
         assertEquals(24119, taggedRelation.getInfo().getUid());
@@ -168,7 +168,7 @@ class ParallelBinaryParserIT {
         assertEquals(81, taggedRelation.getInfo().getVersion());
         assertEquals(1337419064L, taggedRelation.getInfo().getTimestamp());
         assertEquals(11640673, taggedRelation.getInfo().getChangeset());
-        assertFalse(taggedRelation.getInfo().isVisible());
+        assertTrue(taggedRelation.getInfo().isVisible());
     }
 
     @Test

--- a/src/test/java/com/wolt/osm/parallelpbf/TestObjectsFactory.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/TestObjectsFactory.java
@@ -25,6 +25,9 @@ public class TestObjectsFactory {
     public static final Info info = new Info(1, "test", 3, 4, 5, true);
 
     public static final Osmformat.Info infoMessage = Osmformat.Info.newBuilder().setUid(1).setUserSid(2).setVersion(3).setTimestamp(4).setChangeset(5).setVisible(true).build();
+    public static final Osmformat.Info infoMessageWithNullVisibleFlag = Osmformat.Info.newBuilder()
+             .setUid(1).setUserSid(2).setVersion(3).setTimestamp(4).setChangeset(5).build();
+
     public static final Osmformat.StringTable stringTable = Osmformat.StringTable.newBuilder()
             .addS(ByteString.copyFromUtf8(""))
             .addS(ByteString.copyFromUtf8("fail"))
@@ -62,6 +65,14 @@ public class TestObjectsFactory {
             .addKeys(3)
             .addVals(4)
             .setInfo(TestObjectsFactory.infoMessage)
+            .addRefs(9000)
+            .build();
+
+    public static final Osmformat.Way wayMessageWithNullVisibleFlag = Osmformat.Way.newBuilder()
+            .setId(1)
+            .addKeys(3)
+            .addVals(4)
+            .setInfo(TestObjectsFactory.infoMessageWithNullVisibleFlag)
             .addRefs(9000)
             .build();
 

--- a/src/test/java/com/wolt/osm/parallelpbf/parser/InfoParserTest.java
+++ b/src/test/java/com/wolt/osm/parallelpbf/parser/InfoParserTest.java
@@ -94,6 +94,19 @@ class InfoParserTest {
     }
 
     @Test
+    void testWayInfoWithNullVisibleFlag() {
+        var way = Osmformat.Way.newBuilder()
+                .setId(1)
+                .setInfo(TestObjectsFactory.infoMessageWithNullVisibleFlag)
+                .build();
+
+        var testedObject = new InfoParser(null, TestObjectsFactory.stringTable);
+
+        var actual = testedObject.parseInfo(way);
+        Assertions.assertEquals(TestObjectsFactory.info, actual);
+    }
+
+    @Test
     void testRelationInfoMissing() {
         var relation = Osmformat.Relation.newBuilder()
                 .setId(1)


### PR DESCRIPTION
Problem description:
When Read and Write API are used together to create transformed PBF file and visibility attribute was not set in the input PBF then all ways and relations in output PBF have visibility flag set to false. This issue causes error during import PBF using `osm2pgsql` tool: `ERROR: Input file contains deleted objects but you are not in append mode.`